### PR TITLE
add DEV flag for prod github action

### DIFF
--- a/.github/workflows/prod-cd.yaml
+++ b/.github/workflows/prod-cd.yaml
@@ -2,6 +2,8 @@ name: Production CD
 on:
   push:
     branches: [ "main" ]
+env:
+  DEV="false"
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Correctly push to the prod image instead of the dev image in the production github action by adding the DEV=false Makefile flag. 