### PR TITLE
fix syntax error for env variables

### DIFF
--- a/.github/workflows/prod-cd.yaml
+++ b/.github/workflows/prod-cd.yaml
@@ -3,7 +3,7 @@ on:
   push:
     branches: [ "main" ]
 env:
-  DEV="false"
+  DEV: "false"
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Description

Fix a syntax error in `.github/workflows/prod-cd.yaml` by using `:` instead of `=` to define environment variables.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)