### PR TITLE
only get name of deleted branch

### DIFF
--- a/.github/workflows/delete.yaml
+++ b/.github/workflows/delete.yaml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - id: convert
         env:
-            BRANCH_NAME: "${{ github.head_ref || github.ref_name || github.event.ref }}"
+            BRANCH_NAME: "${{ github.event.ref }}"
         run: |
           output=$(echo "$BRANCH_NAME" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed -E 's/^-+|-+$//g')
           echo "name=$output" >> $GITHUB_OUTPUT


### PR DESCRIPTION
# Description

The previous delete branch action deleted the namespace of the default branch instead of the branch that was actually deleted. This fixes that issue.

Fixes # (issue)
N/A

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
