### PR TITLE
fix the name of oauth client metadata file

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -23,7 +23,7 @@ func main() {
 			middleware.LogRequest(),
 		))
 
-	mux.HandleFunc("/oauth-metadata.json",
+	mux.HandleFunc("/client-metadata.json",
 		middleware.Chain(
 			endpoints.ServeOauthMetadata,
 			middleware.LogRequest(),

--- a/internal/endpoints/oauth.go
+++ b/internal/endpoints/oauth.go
@@ -5,5 +5,5 @@ import (
 )
 
 func ServeOauthMetadata(w http.ResponseWriter, r *http.Request) {
-	http.ServeFile(w, r, "/srv/oauth-metadata.json")
+	http.ServeFile(w, r, "/srv/client-metadata.json")
 }


### PR DESCRIPTION
# Description

The name of the oauth client metadata file is `client-metadata.json` but was incorrectly called `oauth-metadata.json`. This PR fixes that issue.

Fixes # (issue)
N/A

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
