### PR TITLE
Add OAuth client metadata to project

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
 export PORT=8080
-export SRV_DIR='/srv/
+export SRV_DIR=/srv

--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
-PORT=8080
+export PORT=8080
+export SRV_DIR='/srv/

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o bin/boshi-backend cmd/main
 FROM alpine:latest
 WORKDIR /app
 COPY --from=build /app/bin/boshi-backend /app/boshi-backend
+COPY --from=build /app/client-metadata.json /srv/client-metadata.json
 ENV PORT=80
+ENV SRV_DIR=/srv
 EXPOSE 80
 ENTRYPOINT ["/app/boshi-backend"]

--- a/client-metadata.json
+++ b/client-metadata.json
@@ -1,0 +1,12 @@
+{
+	"client_id": "https://api-boshi.deguzman.cloud/client-metadata.json",
+	"client_name": "Boshi",
+	"client_uri": "https://api-boshi.deguzman.cloud",
+	"redirect_uris": ["https://api-boshi.deguzman.cloud/"],
+	"grant_types": ["authorization_code", "refresh_token"],
+	"scope": "atproto",
+	"response_types": ["code"],
+	"token_endpoint_auth_method": "none",
+	"application_type": "web",
+	"dpop_bound_access_tokens": true
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -23,7 +23,7 @@ func main() {
 			middleware.LogRequest(),
 		))
 
-	mux.HandleFunc("/oauth-metadata.json",
+	mux.HandleFunc("/client-metadata.json",
 		middleware.Chain(
 			endpoints.ServeOauthMetadata,
 			middleware.LogRequest(),

--- a/internal/endpoints/oauth.go
+++ b/internal/endpoints/oauth.go
@@ -5,5 +5,5 @@ import (
 )
 
 func ServeOauthMetadata(w http.ResponseWriter, r *http.Request) {
-	http.ServeFile(w, r, "/srv/oauth-metadata.json")
+	http.ServeFile(w, r, "/srv/client-metadata.json")
 }

--- a/internal/endpoints/oauth.go
+++ b/internal/endpoints/oauth.go
@@ -2,8 +2,16 @@ package endpoints
 
 import (
 	"net/http"
+	"os"
+	"path/filepath"
 )
 
 func ServeOauthMetadata(w http.ResponseWriter, r *http.Request) {
-	http.ServeFile(w, r, "/srv/client-metadata.json")
+	srvDir := os.Getenv("SRV_DIR")
+	if srvDir == "" {
+		bLogger.Error("SRV_DIR environment variable is not set")
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+	http.ServeFile(w, r, filepath.Join(srvDir, "client-metadata.json"))
 }


### PR DESCRIPTION
# Description

Previously, the OAuth client metadata file was stored directly in the kubernetes configs. This PR adds the metadata file directly to the project and includes it in the built application during the build process with the Dockerfile. An environment variable is also added, mainly for local development.

Fixes # (issue)
N/A

## Type of change

Please delete options that are not relevant.

-   [x] Refactor (non-breaking change which fixes an issue)
