### PR TITLE
Generate `client-metadata.json` for branch previews

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -73,7 +73,6 @@ jobs:
           key: ${{ secrets.SSH_KEY }}
           port: ${{ secrets.SSH_PORT }}
           envs: BRANCH_NAME,REGISTRY
-          script_path: scripts/deployment.sh
           script: |
             if [[ $BRANCH_NAME == "main" ]]; then
               export NAMESPACE="boshi";

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -65,7 +65,7 @@ jobs:
       BRANCH_NAME: ${{needs.convert-branch-name.outputs.name}}
       REGISTRY: ${{ vars.DOCKER_REGISTRY }}
     steps:
-      - name: Create Deployment
+      - name: Create/Update Deployment
         uses: appleboy/ssh-action@v1.2.0
         with:
           host: ${{ secrets.SSH_HOST }}
@@ -73,19 +73,4 @@ jobs:
           key: ${{ secrets.SSH_KEY }}
           port: ${{ secrets.SSH_PORT }}
           envs: BRANCH_NAME,REGISTRY
-          script: |-
-            if [[ $BRANCH_NAME == "main" ]]; then
-              export NAMESPACE="boshi";
-            else
-              export NAMESPACE="boshi-$BRANCH_NAME";
-            fi
-
-            if kubectl get namespace $NAMESPACE >/dev/null 2>&1; then
-              kubectl rollout restart deployment boshi-backend -n $NAMESPACE
-            else
-              kubectl create namespace $NAMESPACE
-              kubectl create deployment boshi-backend --image=$REGISTRY/boshi-backend:$BRANCH_NAME-latest --port=80 -n $NAMESPACE
-              kubectl expose deployment boshi-backend --name=boshi-svc --port=80 --target-port=80 --type=ClusterIP -n $NAMESPACE
-              kubectl create ingress ingress --annotation cert-manager.io/cluster-issuer="letsencrypt-prod" --class=nginx --rule="$BRANCH_NAME-api-boshi.deguzman.cloud/*=boshi-svc:80,tls=boshi-tls" -n $NAMESPACE
-            fi
-
+          script_path: scripts/deployment.sh

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -74,3 +74,18 @@ jobs:
           port: ${{ secrets.SSH_PORT }}
           envs: BRANCH_NAME,REGISTRY
           script_path: scripts/deployment.sh
+          script: |
+            if [[ $BRANCH_NAME == "main" ]]; then
+              export NAMESPACE="boshi";
+            else
+              export NAMESPACE="boshi-$BRANCH_NAME";
+            fi
+
+            if kubectl get namespace $NAMESPACE >/dev/null 2>&1; then
+              kubectl rollout restart deployment boshi-backend -n $NAMESPACE
+            else
+              kubectl create namespace $NAMESPACE
+              kubectl create deployment boshi-backend --image=$REGISTRY/boshi-backend:$BRANCH_NAME-latest --port=80 -n $NAMESPACE
+              kubectl expose deployment boshi-backend --name=boshi-svc --port=80 --target-port=80 --type=ClusterIP -n $NAMESPACE
+              kubectl create ingress ingress --annotation cert-manager.io/cluster-issuer="letsencrypt-prod" --class=nginx --rule="$BRANCH_NAME-api-boshi.deguzman.cloud/*=boshi-svc:80,tls=boshi-tls" -n $NAMESPACE
+            fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Generate client-metadata.json for OAuth2
-FROM debian:bookworm as oauth
+FROM --platform=$BUILDPLATFORM debian:bookworm-slim as oauth
 ARG SUBDOMAIN
 WORKDIR /app
 COPY scripts/generate-client-metadata.sh .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Generate client-metadata.json for OAuth2
-FROM debian:bookworm-slim as oauth
+FROM debian:bookworm as oauth
 ARG SUBDOMAIN
 WORKDIR /app
 COPY scripts/generate-client-metadata.sh .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,22 @@
+# Generate client-metadata.json for OAuth2
+FROM debian:bookworm-slim as oauth
+ARG SUBDOMAIN
+WORKDIR /app
+COPY scripts/generate-client-metadata.sh .
+COPY configs/client-metadata-template.json .
+RUN ./generate-client-metadata.sh client-metadata-template.json $SUBDOMAIN
+
+# Build the Go application
 FROM --platform=$BUILDPLATFORM golang:alpine as build
 WORKDIR /app
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o bin/boshi-backend cmd/main.go
 
+# Build the final image
 FROM alpine:latest
 WORKDIR /app
 COPY --from=build /app/bin/boshi-backend /app/boshi-backend
-COPY --from=build /app/client-metadata.json /srv/client-metadata.json
+COPY --from=oauth /app/client-metadata.json /srv/client-metadata.json
 ENV PORT=80
 ENV SRV_DIR=/srv
 EXPOSE 80

--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,11 @@ docker-push:
 	@echo "Pushing $(BUILD_NAME):$(TAG)..."
 	docker push $(BUILD_NAME):$(TAG)
 
+
 docker:
 	@echo "Building $(BUILD_NAME)..."
-	docker buildx build --platform $(PLATFORM) -t $(BUILD_NAME) .
+	subdomain=$$(scripts/generate-subdomain.sh) && \
+		docker buildx build --build-arg SUBDOMAIN=$${subdomain} --platform $(PLATFORM) -t $(BUILD_NAME) .
 
 clean:
 	@echo "Cleaning bin directory..."

--- a/configs/client-metadata-template.json
+++ b/configs/client-metadata-template.json
@@ -1,8 +1,8 @@
 {
-	"client_id": "https://api-boshi.deguzman.cloud/client-metadata.json",
+	"client_id": "https://<URL>.deguzman.cloud/client-metadata.json",
 	"client_name": "Boshi",
-	"client_uri": "https://api-boshi.deguzman.cloud",
-	"redirect_uris": ["https://api-boshi.deguzman.cloud/"],
+	"client_uri": "https://<URL>.deguzman.cloud",
+	"redirect_uris": ["https://<URL>.deguzman.cloud/"],
 	"grant_types": ["authorization_code", "refresh_token"],
 	"scope": "atproto",
 	"response_types": ["code"],

--- a/scripts/deployment.sh
+++ b/scripts/deployment.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 
 if [[ $BRANCH_NAME == "main" ]]; then

--- a/scripts/deployment.sh
+++ b/scripts/deployment.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+
+if [[ $BRANCH_NAME == "main" ]]; then
+	export NAMESPACE="boshi";
+else
+	export NAMESPACE="boshi-$BRANCH_NAME";
+fi
+
+if kubectl get namespace $NAMESPACE >/dev/null 2>&1; then
+	kubectl rollout restart deployment boshi-backend -n $NAMESPACE
+else
+	kubectl create namespace $NAMESPACE
+	kubectl create deployment boshi-backend --image=$REGISTRY/boshi-backend:$BRANCH_NAME-latest --port=80 -n $NAMESPACE
+	kubectl expose deployment boshi-backend --name=boshi-svc --port=80 --target-port=80 --type=ClusterIP -n $NAMESPACE
+	kubectl create ingress ingress --annotation cert-manager.io/cluster-issuer="letsencrypt-prod" --class=nginx --rule="$BRANCH_NAME-api-boshi.deguzman.cloud/*=boshi-svc:80,tls=boshi-tls" -n $NAMESPACE
+fi
+

--- a/scripts/generate-client-metadata.sh
+++ b/scripts/generate-client-metadata.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# This script generates the client-metadata.json file for OAuth2.0
+cat $1 | sed "s|<URL>|${SUBDOMAIN}|g" > client-metadata.json

--- a/scripts/generate-client-metadata.sh
+++ b/scripts/generate-client-metadata.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script generates the client-metadata.json file for OAuth2.0
 cat $1 | sed "s|<URL>|${SUBDOMAIN}|g" > client-metadata.json

--- a/scripts/generate-subdomain.sh
+++ b/scripts/generate-subdomain.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+branch=$(git branch --show-current)
+
+if [[ $branch == "main" ]]; then
+	echo "api-boshi"
+else
+	echo "$(git branch --show-current | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed -E 's/^-+|-+$$//g')-api-boshi"
+fi

--- a/scripts/generate-subdomain.sh
+++ b/scripts/generate-subdomain.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 branch=$(git branch --show-current)
 


### PR DESCRIPTION
# Description

Previously, the `client-metadata.json` was hardcoded to point to the prod URL. This PR introduces a change so that `client-metadata.json` points to the URL of the branch preview. The pipeline works as follows:

1. Makefile calls `script/generate-subdomain.sh`
2. The script gets the name of the branch and makes it subdomain safe.
3. The output of the script is provided to the Dockerfile as the build argument `SUBDOMAIN`
4. The Dockerfile enters the `oauth` stage. It copies `script/generate-client-metadata.sh` and `configs/client-metadata-template.json` into the stage. Runs the generation script and creates a file `client-metadata.json` that replaces `<URL>` in the template with the subdomain.
5. The build stage copies the `client-metadata.json` to the `/srv` directory.

This allows us to edit the client config and leave the file generation and serving to the build process.

Fixes # (issue)
N/A

## Type of change

Please delete options that are not relevant.

-   [x] New feature (non-breaking change which adds functionality)
